### PR TITLE
Changes --modules option to --modulepath

### DIFF
--- a/5-writing-tasks/README.md
+++ b/5-writing-tasks/README.md
@@ -47,7 +47,7 @@ echo $(hostname) received the message: $PT_message
 We can then run that task using `bolt`. Note the `message` argument. This will be expanded to the `PT_message` environment variable expected by our task. By naming parameters explictly it's easier for others to use your tasks.
 
 ```
-bolt task run exercise5 message=hello --nodes <nodes> --modules ./modules
+bolt task run exercise5 message=hello --nodes <nodes> --modulepath ./modules
 ```
 
 This should result in output similar to:


### PR DESCRIPTION
Updates `--modules` option to documented `--modulepath` option, which corrects error behavior shown below.

```
➜  tasks bolt --version
0.7.0
```

```
➜  tasks bolt task run tasks_demo message=hello --nodes 127.0.0.1:32768 -u root -p root --modules ./modules
Unknown argument '--modules'
```